### PR TITLE
Update Dockerfile to work on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM elixir:1.14.5
 
 # Install debian packages
 RUN apt update \
-    && apt install build-essential inotify-tools postgresql-client git make gcc \
+    && apt install -y build-essential inotify-tools postgresql-client git make gcc \
     && apt clean
 
 ADD . /app


### PR DESCRIPTION
`docker compose up` wasn't working on Windows.
Added the -y (answer automatically yes to all prompts) flag to the apt install command and the error was resolved. 
`RUN apt update \
    && apt install -y build-essential inotify-tools postgresql-client git make gcc \
    && apt clean`
Not entirely sure why it failed before, I was not getting any prompt whatsoever.