### PR TITLE
Owner_Type mismatch with schema

### DIFF
--- a/lib/cursif/notebooks/notebook.ex
+++ b/lib/cursif/notebooks/notebook.ex
@@ -54,7 +54,7 @@ defmodule Cursif.Notebooks.Notebook do
   end
 
   defp validate_association(%{changes: %{owner_type: owner_type}} = changeset)
-       when owner_type not in ["user", "organization"] do
+       when owner_type not in ["User", "organization"] do
     add_error(changeset, :owner_type, "is not a valid owner type")
   end
 


### PR DESCRIPTION
Since the last update of the schema, where we entered default owner_type for creating a new NoteBook, there was a bug when a user tried to create a new notebook. The schema has a capitalized User owner_type, but the validate_association() function had a lowercase user for checking owner_type validation.