### PR TITLE
update workflow version

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,8 +24,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-elixir@v1.5.0
         with:
           elixir-version: '1.14.5'
           otp-version: '25'


### PR DESCRIPTION
The node 16 is deprecated so to fix this warning, I updated the Action Workflow to version 4 which is using Node 20 (currently using version 2 of our workflow). 

I also updated elixir setup version from 1 to 1.5.0.