### PR TITLE
Add lowercase constraint for email validation

### DIFF
--- a/lib/cursif/accounts/user.ex
+++ b/lib/cursif/accounts/user.ex
@@ -60,6 +60,12 @@ defmodule Cursif.Accounts.User do
     |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must have the @ sign and no spaces")
     |> validate_length(:email, max: 160)
     |> unique_constraint(:email)
+    |> lowercase_email()
+  end
+
+  defp lowercase_email(changeset) do
+    changeset
+    |> update_change(:email, &String.downcase/1)
   end
 
   defp validate_password(changeset) do

--- a/lib/cursif/accounts/user.ex
+++ b/lib/cursif/accounts/user.ex
@@ -3,7 +3,7 @@ defmodule Cursif.Accounts.User do
   import Ecto.Changeset
 
   alias Cursif.Repo
-  alias Cursif.Notebooks.Notebook
+  alias Cursif.Notebooks.{Favorite, Notebook}
 
   @type t :: %__MODULE__{
     username: String.t(),

--- a/test/cursif/accounts_test.exs
+++ b/test/cursif/accounts_test.exs
@@ -29,7 +29,7 @@ defmodule Cursif.AccountsTest do
     test "create_user/1 with valid data creates a user" do
       valid_attrs = %{
         username: "jdoe",
-        email: "jdoe@email.com",
+        email: "JdOe@email.com",
         first_name: "John",
         last_name: "Doe",
         password: "HelloWorld!",
@@ -50,7 +50,7 @@ defmodule Cursif.AccountsTest do
       user = user_fixture()
       update_attrs = %{
         username: "jdoe",
-        email: "jdoe@email.com",
+        email: "JDOE@email.com",
         first_name: "John",
         last_name: "Doe",
       }


### PR DESCRIPTION
This pull request adds a lowercase constraint for email validation. Previously, the email field was not being converted to lowercase before validation. This change ensures that all emails are converted to lowercase before validation, allowing for consistent and accurate email validation.