### PR TITLE
Updated Collaborator Handle + Add Notification Email

### DIFF
--- a/lib/cursif/notebooks.ex
+++ b/lib/cursif/notebooks.ex
@@ -6,6 +6,7 @@ defmodule Cursif.Notebooks do
   import Ecto.Query, warn: false
   alias Cursif.Repo
 
+  alias CursifWeb.Emails.UserEmail
   alias Cursif.Notebooks.{Notebook, Collaborator, Favorite}
   alias Cursif.Accounts.{User}
   alias Cursif.Accounts
@@ -207,5 +208,13 @@ defmodule Cursif.Notebooks do
   def delete_favorite_by_user_id(notebook_id, user_id) do
     Repo.delete_all(from n in Favorite,
       where: n.user_id == ^user_id and n.notebook_id == ^notebook_id)
+  end
+
+  @doc """
+  Send invite to a collaborator.
+  """
+  def send_invite(%User{} = user, notebook_id) do
+    # Send email to email
+    UserEmail.send_collaborator_invitation_email(user, notebook_id)
   end
 end

--- a/lib/cursif/notebooks.ex
+++ b/lib/cursif/notebooks.ex
@@ -214,7 +214,6 @@ defmodule Cursif.Notebooks do
   Send invite to a collaborator.
   """
   def send_invite(%User{} = user, notebook_id, owner) do
-    # Send email to email
     UserEmail.send_collaborator_invitation_email(user, notebook_id, owner)
   end
 end

--- a/lib/cursif/notebooks.ex
+++ b/lib/cursif/notebooks.ex
@@ -213,7 +213,7 @@ defmodule Cursif.Notebooks do
   @doc """
   Send invite to a collaborator.
   """
-  def send_invite(%User{} = user, notebook_id, owner) do
-    UserEmail.send_collaborator_invitation_email(user, notebook_id, owner)
+  def send_notification(%User{} = user, notebook_id, owner) do
+    UserEmail.send_collaborator_email(user, notebook_id, owner)
   end
 end

--- a/lib/cursif/notebooks.ex
+++ b/lib/cursif/notebooks.ex
@@ -213,8 +213,8 @@ defmodule Cursif.Notebooks do
   @doc """
   Send invite to a collaborator.
   """
-  def send_invite(%User{} = user, notebook_id) do
+  def send_invite(%User{} = user, notebook_id, owner) do
     # Send email to email
-    UserEmail.send_collaborator_invitation_email(user, notebook_id)
+    UserEmail.send_collaborator_invitation_email(user, notebook_id, owner)
   end
 end

--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -43,8 +43,8 @@ defmodule CursifWeb.Emails.UserEmail do
   @doc """
   Sends a collaboration invitation email to a user.
   """
-  def send_collaborator_invitation_email(user, notebook, owner) do
+  def send_collaborator_email(user, notebook, owner) do
     base_url = "#{@client_url}/notebooks/#{notebook}"
-    send_email(user, "Cursif ~ Collaboration Invitation", base_url, "invite.html", %{owner: owner})
+    send_email(user, "Cursif ~ Collaboration Notification", base_url, "add.html", %{owner: owner})
   end
 end

--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -37,4 +37,12 @@ defmodule CursifWeb.Emails.UserEmail do
     base_url = "#{@client_url}/reset-password?token=#{token}"
     send_email(user, "Cursif ~ Password Reset", base_url, "reset.html")
   end
+
+  @doc """
+  Sends a collaboration invitation email to a user.
+  """
+  def send_collaborator_invitation_email(user, notebook) do
+    base_url = "#{@client_url}/notebooks/#{notebook}"
+    send_email(user, "Cursif ~ Collaboration Invitation", base_url, "invite.html")
+  end
 end

--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -9,13 +9,15 @@ defmodule CursifWeb.Emails.UserEmail do
   @client_url Application.compile_env(:cursif, :client_url)
   @client_email Application.compile_env(:cursif, :email_sender)
 
-  defp send_email(user, subject, base_url, context) do
+  defp send_email(user, subject, base_url, context, extra_context \\ %{}) do
+    email_context = Map.merge(%{username: user.username, base_url: base_url}, extra_context)
+    
     email =
       new()
       |> from({"Cursif", @client_email})
       |> to(user.email)
       |> subject(subject)
-      |> render_body(context, %{username: user.username, base_url: base_url})
+      |> render_body(context, email_context)
     
     with {:ok, _metadata} <- Mailer.deliver(email) do
       {:ok, email}
@@ -41,8 +43,8 @@ defmodule CursifWeb.Emails.UserEmail do
   @doc """
   Sends a collaboration invitation email to a user.
   """
-  def send_collaborator_invitation_email(user, notebook) do
+  def send_collaborator_invitation_email(user, notebook, owner) do
     base_url = "#{@client_url}/notebooks/#{notebook}"
-    send_email(user, "Cursif ~ Collaboration Invitation", base_url, "invite.html")
+    send_email(user, "Cursif ~ Collaboration Invitation", base_url, "invite.html", %{owner: owner})
   end
 end

--- a/lib/cursif_web/resolvers/collaborators.ex
+++ b/lib/cursif_web/resolvers/collaborators.ex
@@ -12,10 +12,9 @@ defmodule CursifWeb.Resolvers.Collaborators do
 
 		user = Accounts.get_user_by_email!(collaborator.email)
 		collaborator_attrs = %{notebook_id: collaborator.notebook_id, user_id: user.id}
-		
 		case Notebooks.add_collaborator(collaborator_attrs) do
 			{:ok, collaborator} ->
-				case Notebooks.send_invite(user, collaborator.notebook_id) do
+				case Notebooks.send_invite(user, collaborator.notebook_id, current_user) do
 					{:ok, _} -> {:ok, collaborator}
 					{:error, reason} -> {:error, reason}
 				end

--- a/lib/cursif_web/resolvers/collaborators.ex
+++ b/lib/cursif_web/resolvers/collaborators.ex
@@ -14,7 +14,7 @@ defmodule CursifWeb.Resolvers.Collaborators do
 		collaborator_attrs = %{notebook_id: collaborator.notebook_id, user_id: user.id}
 		case Notebooks.add_collaborator(collaborator_attrs) do
 			{:ok, collaborator} ->
-				case Notebooks.send_invite(user, collaborator.notebook_id, current_user) do
+				case Notebooks.send_notification(user, collaborator.notebook_id, current_user) do
 					{:ok, _} -> {:ok, collaborator}
 					{:error, reason} -> {:error, reason}
 				end

--- a/lib/cursif_web/resolvers/collaborators.ex
+++ b/lib/cursif_web/resolvers/collaborators.ex
@@ -1,6 +1,7 @@
 defmodule CursifWeb.Resolvers.Collaborators do
 	alias Cursif.Notebooks
 	alias Cursif.Notebooks.Collaborator
+	alias Cursif.Accounts
 
 	@spec add_collaborator(map(), map()) :: {:ok, Collaborator.t()}  | {:error, atom()}
 	def add_collaborator(collaborator, %{context: %{current_user: current_user}}) do
@@ -8,8 +9,11 @@ defmodule CursifWeb.Resolvers.Collaborators do
 			collaborator.notebook_id,
 			owner: current_user
 		)
-			
-		case Notebooks.add_collaborator(collaborator) do
+
+		user = Accounts.get_user_by_email!(collaborator.email)
+		collaborator_attrs = %{notebook_id: collaborator.notebook_id, user_id: user.id}
+		
+		case Notebooks.add_collaborator(collaborator_attrs) do
 			{:ok, collaborator} -> {:ok, collaborator}
 			{:error, changeset} -> {:error, changeset}
 		end

--- a/lib/cursif_web/resolvers/collaborators.ex
+++ b/lib/cursif_web/resolvers/collaborators.ex
@@ -14,7 +14,12 @@ defmodule CursifWeb.Resolvers.Collaborators do
 		collaborator_attrs = %{notebook_id: collaborator.notebook_id, user_id: user.id}
 		
 		case Notebooks.add_collaborator(collaborator_attrs) do
-			{:ok, collaborator} -> {:ok, collaborator}
+			{:ok, collaborator} ->
+				case Notebooks.send_invite(user, collaborator.notebook_id) do
+					{:ok, _} -> {:ok, collaborator}
+					{:error, reason} -> {:error, reason}
+				end
+			{:ok, collaborator}
 			{:error, changeset} -> {:error, changeset}
 		end
 	end

--- a/lib/cursif_web/schemas/notebook.ex
+++ b/lib/cursif_web/schemas/notebook.ex
@@ -40,7 +40,7 @@ defmodule CursifWeb.Schemas.Notebook do
         arg(:title, non_null(:string))
         arg(:description, :string)
         arg(:owner_id, non_null(:id))
-        arg(:owner_type, :string, default_value: "User")
+        arg(:owner_type, :string, default_value: "user")
 
         resolve(&Notebooks.create_notebook/2)
       end

--- a/lib/cursif_web/schemas/notebook.ex
+++ b/lib/cursif_web/schemas/notebook.ex
@@ -93,7 +93,8 @@ defmodule CursifWeb.Schemas.Notebook do
       @desc "Add a collaborator"
       field :add_collaborator, :collaborator do
         arg(:notebook_id, non_null(:id))
-        arg(:user_id, non_null(:id))
+        arg(:user_id, :id)
+        arg(:email, non_null(:string))
 
         resolve(&Collaborators.add_collaborator/2)
       end

--- a/lib/cursif_web/schemas/types/notebook_types.ex
+++ b/lib/cursif_web/schemas/types/notebook_types.ex
@@ -43,6 +43,7 @@ defmodule CursifWeb.Schemas.NotebookTypes do
     field :id, :id
     field :notebook_id, :string
     field :user_id, :string
+    field :email, :string
   end
 
   @desc "Favorite representation"

--- a/lib/cursif_web/templates/email/add.html.eex
+++ b/lib/cursif_web/templates/email/add.html.eex
@@ -10,11 +10,10 @@
           <p>Hi <strong><%= @username %></strong>,</p>
           <p>
             You have been added to a notebook by <%= @owner.username%> (<strong><%= @owner.email%></strong>).
-            Click the button below to join the notebook and start collaborating with your team today.
           </p>
         </div>
         <div class="button-container">
-          <a class="button" href="<%= @base_url %>">Join the notebook</a>
+          <a class="button" href="<%= @base_url %>">Notebook</a>
           <div class="message signature">
             <p>If you didn't sign up for Cursif, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/add.html.eex
+++ b/lib/cursif_web/templates/email/add.html.eex
@@ -13,9 +13,9 @@
           </p>
         </div>
         <div class="button-container">
-          <a class="button" href="<%= @base_url %>">Notebook</a>
+          <a class="button" href="<%= @base_url %>">See Notebook</a>
           <div class="message signature">
-            <p>If you didn't sign up for Cursif, please disregard this email.</p>
+            <p>If it isn't you, please disregard this email.</p>
           </div>
       </div>
       <div style="margin-left: 20px" class="email-signature signature">

--- a/lib/cursif_web/templates/email/invite.html.eex
+++ b/lib/cursif_web/templates/email/invite.html.eex
@@ -9,7 +9,7 @@
         <div class="email-body">
           <p>Hi <strong><%= @username %></strong>,</p>
           <p>
-            You have been added to a notebook on Cursif.
+            You have been added to a notebook  by <%= @owner.username%> (<strong><%= @owner.email%></strong>).
             Click the button below to join the notebook and start collaborating with your team today.
           </p>
         </div>

--- a/lib/cursif_web/templates/email/invite.html.eex
+++ b/lib/cursif_web/templates/email/invite.html.eex
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="email-container">
+      <div class="header">
+        <span style="font-family: Montez; font-size: 1.2em;">Cursif</span>
+      </div>
+      <div class="content">
+        <div class="email-body">
+          <p>Hi <strong><%= @username %></strong>,</p>
+          <p>
+            You have been added to a notebook on Cursif.
+            Click the button below to join the notebook and start collaborating with your team today.
+          </p>
+        </div>
+        <div class="button-container">
+          <a class="button" href="<%= @base_url %>">Join the notebook</a>
+          <div class="message signature">
+            <p>If you didn't sign up for Cursif, please disregard this email.</p>
+          </div>
+      </div>
+      <div style="margin-left: 20px" class="email-signature signature">
+        <p>
+          Best regards,<br />
+          The Cursif Team
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/lib/cursif_web/templates/email/invite.html.eex
+++ b/lib/cursif_web/templates/email/invite.html.eex
@@ -9,7 +9,7 @@
         <div class="email-body">
           <p>Hi <strong><%= @username %></strong>,</p>
           <p>
-            You have been added to a notebook  by <%= @owner.username%> (<strong><%= @owner.email%></strong>).
+            You have been added to a notebook by <%= @owner.username%> (<strong><%= @owner.email%></strong>).
             Click the button below to join the notebook and start collaborating with your team today.
           </p>
         </div>


### PR DESCRIPTION
The PR adds the functionality to send a notification email to a collaborator that has just been added to a notebook. This feature allows users to add others to collaborate on a notebook.

This PR also includes the following:
- Update the collaborator field to implement the frontend feature where the user will use the user email address rather than the user ID (which makes more sense that way too).
- Update owner_type that causes an error when trying to fetch notebook owner. the owner_type was an uppercase User instead of a lowercase user.

This PR is a blocker for the frontend, thus need to be merged prior the following:
- [ ] https://github.com/Code-Society-Lab/cursif-web/pull/53