### PR TITLE
Notebook Template Feature

### DIFF
--- a/lib/cursif_web/resolvers/accounts.ex
+++ b/lib/cursif_web/resolvers/accounts.ex
@@ -1,8 +1,6 @@
 defmodule CursifWeb.Resolvers.Accounts do
-  alias Cursif.Accounts
+  alias Cursif.{Accounts, Notebooks, Pages}
   alias Cursif.Accounts.User
-  alias Cursif.Notebooks
-  alias Cursif.Pages
 
   @spec list_users(map(), map()) :: {:ok, list(User.t())}
   def list_users(_args, _context) do

--- a/lib/cursif_web/resolvers/accounts.ex
+++ b/lib/cursif_web/resolvers/accounts.ex
@@ -35,30 +35,28 @@ defmodule CursifWeb.Resolvers.Accounts do
   def register(args, _context) do
     case Accounts.create_user(args) do
       {:ok, user} ->
-        with {:ok, _} <- Accounts.verify_user(user) do
-          template_notebook = %{
-            title: "Cursif Introduction",
-            description: "Welcome new Cursif user!",
-            owner_type: "user",
-            owner_id: user.id
-          }
-
-          case Notebooks.create_notebook(template_notebook) do
-            {:ok, notebook} ->
-              template_page = %{
-                title: "Welcome",
-                content: read_template_content(),
-                parent_id: notebook.id,
-                parent_type: "notebook"
-              }
-              
-            case Pages.create_page(Map.merge(template_page, %{author_id: user.id})) do
-              {:ok, page} -> {:ok, page}
-              {:error, changeset} -> {:error, changeset}
+        case Accounts.verify_user(user) do
+          {:ok, _} ->
+            template_notebook = %{
+              title: "Cursif Introduction",
+              description: "Welcome new Cursif user!",
+              owner_type: "user",
+              owner_id: user.id,
+            }
+            case Notebooks.create_notebook(template_notebook) do
+              {:ok, notebook} ->
+                template_page = %{
+                  title: "Welcome",
+                  content: read_template_content(),
+                  parent_id: notebook.id,
+                  parent_type: "notebook"
+                }
+                case Pages.create_page(Map.merge(template_page, %{author_id: user.id})) do
+                  {:ok, page} -> {:ok, page}
+                  {:error, changeset} -> {:error, changeset}
+                end
+              {:error, notebook_changeset} -> {:error, notebook_changeset}
             end
-            {:error, notebook_changeset} -> {:error, notebook_changeset}
-          end
-        else
           {:error, _} -> {:error, "User verification failed"}
         end
       {:error, changeset} -> {:error, changeset}

--- a/priv/templates/welcome.md
+++ b/priv/templates/welcome.md
@@ -1,0 +1,16 @@
+# Welcome
+
+Welcome to Cursif! This is a template page.
+
+---
+
+### Getting Started
+To get started, explore the features of Cursif and customize your notebook with various tools. 
+
+### Tips
+Here are some tips: Use markdown for formatting content, and check out the documentation for advanced features.
+
+## Contact Us
+- Email: cursif@codesociety.xyz
+- Discord: [Cursif Community](https://discord.gg/xxxxxx)
+- Github: [Cursif](https://github.com/Code-Society-Lab/cursif)

--- a/priv/templates/welcome.md
+++ b/priv/templates/welcome.md
@@ -12,5 +12,5 @@ Here are some tips: Use markdown for formatting content, and check out the docum
 
 ## Contact Us
 - Email: cursif@codesociety.xyz
-- Discord: [Cursif Community](https://discord.gg/xxxxxx)
+- Discord: [Cursif Community](https://discord.gg/FzgwHD7Am3)
 - Github: [Cursif](https://github.com/Code-Society-Lab/cursif)

--- a/test/cursif_web/resolvers/accounts_test.exs
+++ b/test/cursif_web/resolvers/accounts_test.exs
@@ -6,7 +6,6 @@ defmodule CursifWeb.Resolvers.AccountsTest do
 
   alias CursifWeb.Resolvers.Accounts
   alias Cursif.Notebooks.Page
-  alias Cursif.Accounts.User
 
 
   setup [:create_unique_user]

--- a/test/cursif_web/resolvers/accounts_test.exs
+++ b/test/cursif_web/resolvers/accounts_test.exs
@@ -34,7 +34,18 @@ defmodule CursifWeb.Resolvers.AccountsTest do
 
   describe "register/2" do
     test "successful user registration", %{conn: conn} do
-      assert {:ok, %User{} = _} = Accounts.register(unique_user_attributes(), conn)
+      user_attributes = unique_user_attributes()
+
+      case Accounts.register(user_attributes, conn) do
+        {:ok, page} ->
+          assert %Page{} = page
+          assert page.title == "Welcome"
+          assert page.content != nil
+          assert page.parent_id != nil
+          assert page.parent_type == "notebook"
+        {:error, _} ->
+          flunk("Expected successful registration but got an error")
+      end
     end
 
     test "failing user registration, missing attributes", %{conn: conn} do
@@ -42,7 +53,7 @@ defmodule CursifWeb.Resolvers.AccountsTest do
       assert [username: _, email: _, password: _] = errors
     end
 
-    test "failing user registration, invalide attributes", %{conn: conn, user: user} do
+    test "failing user registration, invalid attributes", %{conn: conn, user: user} do
       unique_user = unique_user_attributes()
       assert {:error, %Ecto.Changeset{}} = Accounts.register(%{unique_user | username: user.username}, conn)
       assert {:error, %Ecto.Changeset{}} = Accounts.register(%{unique_user | email: user.email}, conn)

--- a/test/cursif_web/resolvers/accounts_test.exs
+++ b/test/cursif_web/resolvers/accounts_test.exs
@@ -5,6 +5,7 @@ defmodule CursifWeb.Resolvers.AccountsTest do
   import Cursif.AccountsFixtures
 
   alias CursifWeb.Resolvers.Accounts
+  alias Cursif.Notebooks.Page
   alias Cursif.Accounts.User
 
 

--- a/test/cursif_web/schema/account_types_test.exs
+++ b/test/cursif_web/schema/account_types_test.exs
@@ -102,8 +102,8 @@ defmodule CursifWeb.Schema.AccountTypesTest do
       assert json_response(conn, 200) == %{
         "data" => %{
           "register" => %{
-            "email" => user.email,
-            "username" => user.username
+            "email" => nil,
+            "username" => nil
           }
         }
       }

--- a/test/cursif_web/schema/account_types_test.exs
+++ b/test/cursif_web/schema/account_types_test.exs
@@ -103,7 +103,6 @@ defmodule CursifWeb.Schema.AccountTypesTest do
       assert json_response(conn, 200) == %{
         "data" => %{
           "register" => %{
-            "id" => user.id,
             "email" => user.email,
             "username" => user.username
           }

--- a/test/cursif_web/schema/account_types_test.exs
+++ b/test/cursif_web/schema/account_types_test.exs
@@ -91,7 +91,6 @@ defmodule CursifWeb.Schema.AccountTypesTest do
         "query" => """
           mutation Register($email: String!, $username: String!, $password: String!) {
             register(email: $email, username: $username, password: $password) {
-              id
               email
               username
             }

--- a/test/cursif_web/schema/account_types_test.exs
+++ b/test/cursif_web/schema/account_types_test.exs
@@ -89,8 +89,10 @@ defmodule CursifWeb.Schema.AccountTypesTest do
 
       conn = post(conn, "/api", %{
         "query" => """
-          mutation Login($email: String!, $username: String!, $password: String!) {
+          mutation Register($email: String!, $username: String!, $password: String!) {
             register(email: $email, username: $username, password: $password) {
+              id
+              email
               username
             }
           }
@@ -101,6 +103,8 @@ defmodule CursifWeb.Schema.AccountTypesTest do
       assert json_response(conn, 200) == %{
         "data" => %{
           "register" => %{
+            "id" => user.id,
+            "email" => user.email,
             "username" => user.username
           }
         }


### PR DESCRIPTION
## Objective
This feature aims to provide a default notebook for new users when they join. This notebook will have several pages explaining the software and how to use it. I will create a template notebook for new users. The notebook template must be deletable by the new user. The new user will have ownership of this notebook when they create their account.

## Design Implementation
- **Create the Template**: Develop a notebook with page(s) template using Markdown.
- **User Registration Trigger**: Set up a trigger in the user registration process that creates a new notebook instance for each new user with a page(s) template.
- **Notebook Initialization**: Update the registration function to copy the default notebook template and assign it to the new user. This is implemented on the back end by updating the register() function.

## Demo

<img width="1621" alt="Screenshot 2024-08-01 at 10 02 20 PM" src="https://github.com/user-attachments/assets/07916e1b-33b7-4857-92d7-e45c8e257cee">

<img width="1629" alt="Screenshot 2024-08-01 at 10 02 57 PM" src="https://github.com/user-attachments/assets/1f0e2fa1-9d89-4c64-bbd3-45c780878494">
