### PR TITLE
Visible token in Password Reset, Account Verification, and New Collab emails

### DIFF
--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -9,7 +9,7 @@ defmodule CursifWeb.Emails.UserEmail do
   @client_url Application.compile_env(:cursif, :client_url)
   @client_email Application.compile_env(:cursif, :email_sender)
 
-  defp send_email(user, subject, base_url, context, extra_context) do
+  defp send_email(user, subject, base_url, context, extra_context \\ %{}) do
     email_context = Map.merge(%{username: user.username, base_url: base_url}, extra_context)
     
     email =
@@ -29,7 +29,7 @@ defmodule CursifWeb.Emails.UserEmail do
   """
   def send_confirmation_email(user, token) do
     base_url = "#{@client_url}/confirm?token=#{token}"
-    send_email(user, "Welcome to Cursif ~ Email Verification", base_url, "welcome.html", %{token: token})
+    send_email(user, "Welcome to Cursif ~ Email Verification", base_url, "welcome.html")
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule CursifWeb.Emails.UserEmail do
   """
   def send_password_reset_email(user, token) do
     base_url = "#{@client_url}/reset-password?token=#{token}"
-    send_email(user, "Cursif ~ Password Reset", base_url, "reset.html", %{token: token})
+    send_email(user, "Cursif ~ Password Reset", base_url, "reset.html")
   end
 
   @doc """

--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -29,7 +29,7 @@ defmodule CursifWeb.Emails.UserEmail do
   """
   def send_confirmation_email(user, token) do
     base_url = "#{@client_url}/confirm?token=#{token}"
-    send_email(user, "Welcome to Cursif ~ Email Verification", base_url, "welcome.html")
+    send_email(user, "Welcome to Cursif ~ Email Verification", base_url, "welcome.html", %{token: token})
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule CursifWeb.Emails.UserEmail do
   """
   def send_password_reset_email(user, token) do
     base_url = "#{@client_url}/reset-password?token=#{token}"
-    send_email(user, "Cursif ~ Password Reset", base_url, "reset.html")
+    send_email(user, "Cursif ~ Password Reset", base_url, "reset.html", %{token: token})
   end
 
   @doc """

--- a/lib/cursif_web/emails/user_email.ex
+++ b/lib/cursif_web/emails/user_email.ex
@@ -9,7 +9,7 @@ defmodule CursifWeb.Emails.UserEmail do
   @client_url Application.compile_env(:cursif, :client_url)
   @client_email Application.compile_env(:cursif, :email_sender)
 
-  defp send_email(user, subject, base_url, context, extra_context \\ %{}) do
+  defp send_email(user, subject, base_url, context, extra_context) do
     email_context = Map.merge(%{username: user.username, base_url: base_url}, extra_context)
     
     email =

--- a/lib/cursif_web/templates/email/add.html.eex
+++ b/lib/cursif_web/templates/email/add.html.eex
@@ -13,7 +13,8 @@
           </p>
         </div>
         <div class="button-container">
-          <a class="button" href="<%= @base_url %>">See Notebook</a>
+          <a class="button" href="<%= @base_url %>">See Notebook</a><br><br>
+          <a style="color: gray; font-size: 0.6em; word-wrap: break-word;" href="<%= @base_url %>"><%= @base_url %></a>
           <div class="message signature">
             <p>If it isn't you, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/reset.html.eex
+++ b/lib/cursif_web/templates/email/reset.html.eex
@@ -15,6 +15,7 @@
         </div>
         <div class="button-container">
           <a class="button" href="<%= @base_url %>">Reset your password</a>
+          <p style="color: gray; font-size: 0.6em; word-wrap: break-word;"><%= @token %></p>
           <div class="message signature">
             <p>If you didn't request a new password, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/reset.html.eex
+++ b/lib/cursif_web/templates/email/reset.html.eex
@@ -15,7 +15,7 @@
         </div>
         <div class="button-container">
           <a class="button" href="<%= @base_url %>">Reset your password</a>
-          <p style="color: gray; font-size: 0.6em; word-wrap: break-word;"><%= @token %></p>
+          <a style="color: gray; font-size: 0.6em; word-wrap: break-word;" href="<%= @base_url %>"><%= @base_url %></a>
           <div class="message signature">
             <p>If you didn't request a new password, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/reset.html.eex
+++ b/lib/cursif_web/templates/email/reset.html.eex
@@ -14,7 +14,7 @@
           </p>
         </div>
         <div class="button-container">
-          <a class="button" href="<%= @base_url %>">Reset your password</a>
+          <a class="button" href="<%= @base_url %>">Reset your password</a><br><br>
           <a style="color: gray; font-size: 0.6em; word-wrap: break-word;" href="<%= @base_url %>"><%= @base_url %></a>
           <div class="message signature">
             <p>If you didn't request a new password, please disregard this email.</p>

--- a/lib/cursif_web/templates/email/welcome.html.eex
+++ b/lib/cursif_web/templates/email/welcome.html.eex
@@ -15,7 +15,7 @@
         </div>
         <div class="button-container">
           <a class="button" href="<%= @base_url %>">Verify your account</a>
-          <p style="color: gray; font-size: 0.6em; word-wrap: break-word;"><%= @token %></p>
+          <a style="color: gray; font-size: 0.6em; word-wrap: break-word;" href="<%= @base_url %>"><%= @base_url %></a>
           <div class="message signature">
             <p>If you didn't sign up for Cursif, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/welcome.html.eex
+++ b/lib/cursif_web/templates/email/welcome.html.eex
@@ -14,7 +14,7 @@
           </p>
         </div>
         <div class="button-container">
-          <a class="button" href="<%= @base_url %>">Verify your account</a>
+          <a class="button" href="<%= @base_url %>">Verify your account</a><br><br>
           <a style="color: gray; font-size: 0.6em; word-wrap: break-word;" href="<%= @base_url %>"><%= @base_url %></a>
           <div class="message signature">
             <p>If you didn't sign up for Cursif, please disregard this email.</p>

--- a/lib/cursif_web/templates/email/welcome.html.eex
+++ b/lib/cursif_web/templates/email/welcome.html.eex
@@ -15,6 +15,7 @@
         </div>
         <div class="button-container">
           <a class="button" href="<%= @base_url %>">Verify your account</a>
+          <p style="color: gray; font-size: 0.9em; word-wrap: break-word;"><%= @token %></p>
           <div class="message signature">
             <p>If you didn't sign up for Cursif, please disregard this email.</p>
           </div>

--- a/lib/cursif_web/templates/email/welcome.html.eex
+++ b/lib/cursif_web/templates/email/welcome.html.eex
@@ -15,7 +15,7 @@
         </div>
         <div class="button-container">
           <a class="button" href="<%= @base_url %>">Verify your account</a>
-          <p style="color: gray; font-size: 0.9em; word-wrap: break-word;"><%= @token %></p>
+          <p style="color: gray; font-size: 0.6em; word-wrap: break-word;"><%= @token %></p>
           <div class="message signature">
             <p>If you didn't sign up for Cursif, please disregard this email.</p>
           </div>


### PR DESCRIPTION
This PR adds a clickable URL link under the button for account confirmation, password reset, and new collaboration.
See Issue #35 

<img width="689" alt="Screenshot 2024-08-01 at 11 04 32 PM" src="https://github.com/user-attachments/assets/8a19b9c7-a881-4888-ab80-b47028244da7">

Screenshot deprecated. You now have the full URL with the token under the button.
